### PR TITLE
機器/ユーザー/設置場所の順へ統一

### DIFF
--- a/HardwareInformationManagement/Controllers/hardController.vb
+++ b/HardwareInformationManagement/Controllers/hardController.vb
@@ -122,12 +122,12 @@ Namespace Controllers
         End Sub
 
         Private Sub SetDropDownCreate()
-            'ユーザーIDのプルダウン
+            '設置場所IDのプルダウン
             Dim positionList = db.dt_position.ToList()
             positionList.Insert(0, New dt_position With {.Id = 0, .position = japanese.please_select})
             ViewBag.position_id = New SelectList(positionList, "Id", "position")
 
-            '設置場所IDのプルダウン
+            'ユーザーIDのプルダウン
             Dim userList = db.dt_user.ToList()
             userList.Insert(0, New dt_user With {.Id = 0, .user = japanese.please_select})
             ViewBag.user_id = New SelectList(userList, "Id", "user")

--- a/HardwareInformationManagement/Views/hard/Delete.vbhtml
+++ b/HardwareInformationManagement/Views/hard/Delete.vbhtml
@@ -18,19 +18,19 @@ End Code
         </dd>
 
         <dt>
-            @ViewBag.japanese.position_name
-        </dt>
-
-        <dd>
-            @Html.DisplayFor(Function(model) model.dt_position.position)
-        </dd>
-
-        <dt>
             @ViewBag.japanese.user_name
         </dt>
 
         <dd>
             @Html.DisplayFor(Function(model) model.dt_user.user)
+        </dd>
+
+        <dt>
+            @ViewBag.japanese.position_name
+        </dt>
+
+        <dd>
+            @Html.DisplayFor(Function(model) model.dt_position.position)
         </dd>
 
         <dt>

--- a/HardwareInformationManagement/Views/hard/Details.vbhtml
+++ b/HardwareInformationManagement/Views/hard/Details.vbhtml
@@ -17,19 +17,19 @@ End Code
         </dd>
 
         <dt>
-            @ViewBag.japanese.position_name
-        </dt>
-
-        <dd>
-            @Html.DisplayFor(Function(model) model.dt_position.position)
-        </dd>
-
-        <dt>
             @ViewBag.japanese.user_name
         </dt>
 
         <dd>
             @Html.DisplayFor(Function(model) model.dt_user.user)
+        </dd>
+
+        <dt>
+            @ViewBag.japanese.position_name
+        </dt>
+
+        <dd>
+            @Html.DisplayFor(Function(model) model.dt_position.position)
         </dd>
 
         <dt>

--- a/HardwareInformationManagement/Views/hard/Index.vbhtml
+++ b/HardwareInformationManagement/Views/hard/Index.vbhtml
@@ -14,10 +14,10 @@ End Code
             @ViewBag.japanese.hard_name
         </th>
         <th>
-            @ViewBag.japanese.position_name
+            @ViewBag.japanese.user_name
         </th>
         <th>
-            @ViewBag.japanese.user_name
+            @ViewBag.japanese.position_name
         </th>
         <th>
             @ViewBag.japanese.hard_comment
@@ -31,10 +31,10 @@ End Code
                 @Html.DisplayFor(Function(modelItem) item.hard)
             </td>
             <td>
-                @Html.DisplayFor(Function(modelItem) item.dt_position.position)
+                @Html.DisplayFor(Function(modelItem) item.dt_user.user)
             </td>
             <td>
-                @Html.DisplayFor(Function(modelItem) item.dt_user.user)
+                @Html.DisplayFor(Function(modelItem) item.dt_position.position)
             </td>
             <td>
                 @Html.DisplayFor(Function(modelItem) item.comment)


### PR DESCRIPTION
# What
各種ページの項目順を統一

# Why
ユーザビリティを確保するため